### PR TITLE
Check whether the table exists before applying the Schema

### DIFF
--- a/lib/adapters/sqlite3.js
+++ b/lib/adapters/sqlite3.js
@@ -127,7 +127,17 @@
     };
 
     SQLite3Adapter.prototype.applySchema = function(model, callback) {
-      return this._createTable(model, callback);
+      var tableName;
+      tableName = this._connection.models[model].tableName;
+      return this._query('all', "SELECT name FROM sqlite_master WHERE type='table' AND name='" + tableName + "'", (function(_this) {
+        return function(error, result) {
+          if ((result != null ? result.length : void 0) !== 1) {
+            return _this._createTable(model, callback);
+          } else {
+            return callback(null);
+          }
+        };
+      })(this));
     };
 
     SQLite3Adapter.prototype.drop = function(model, callback) {

--- a/src/adapters/sqlite3.coffee
+++ b/src/adapters/sqlite3.coffee
@@ -80,8 +80,12 @@ class SQLite3Adapter extends SQLAdapterBase
 
   ## @override AdapterBase::applySchema
   applySchema: (model, callback) ->
-    # TODO check table existence
-    @_createTable model, callback
+    tableName = @_connection.models[model].tableName
+    @_query 'all', "SELECT name FROM sqlite_master WHERE type='table' AND name='#{tableName}'", (error, result) =>
+      if result?.length != 1
+        @_createTable model, callback
+      else
+        callback null
 
   ## @override AdapterBase::drop
   drop: (model, callback) ->


### PR DESCRIPTION
I found out that Cormo was crashing with Sqlite when using an existing database. This meant that Cormo worked well the first time I started the app, and broke the following times.

This patch should fix that, though I haven't implemented the "alterTable" method, like the Mysql adapter does.
