### PR TITLE
Make IQuerySingle result type nullable

### DIFF
--- a/packages/cormo/src/query.ts
+++ b/packages/cormo/src/query.ts
@@ -55,7 +55,7 @@ export interface IQuerySingle<M extends BaseModel, T = M> extends PromiseLike<T>
   transaction(transaction?: Transaction): IQuerySingle<M, T>;
   using(node: 'master' | 'read'): IQuerySingle<M, T>;
 
-  exec(options?: { skip_log?: boolean }): PromiseLike<T>;
+  exec(options?: { skip_log?: boolean }): PromiseLike<T | null>;
   stream(): stream.Readable;
   explain(): PromiseLike<any>;
   count(): PromiseLike<number>;


### PR DESCRIPTION
저는 알고 있어서 null checking을 하고 있긴 한데 type checking 딴에서 알려줘야 합니다.

테스트는 `npm run test`로만 해봤습니다.

```typescript
    if (this._options.one) {
      if (records.length > 1) {
        throw new Error('unknown error');
      }
      if (records.length === 1) {
        return records[0];
      } else {
        return null;
      }
    }
```