### PR TITLE
cormo: Fix column name in SchemaChange

### DIFF
--- a/packages/cormo/lib/connection/index.js
+++ b/packages/cormo/lib/connection/index.js
@@ -226,11 +226,11 @@ class Connection extends events_1.EventEmitter {
             for (const column in modelClass._schema) {
                 const property = modelClass._schema[column];
                 if (!currentTable[property._dbname_us]) {
-                    changes.push({ message: `Add column ${column} to ${modelClass.table_name}` });
+                    changes.push({ message: `Add column ${property._dbname_us} to ${modelClass.table_name}` });
                 }
                 else if (column !== 'id') {
                     if (property.required && !currentTable[property._dbname_us].required) {
-                        changes.push({ message: `Change ${modelClass.table_name}.${column} to required`, ignorable: true });
+                        changes.push({ message: `Change ${modelClass.table_name}.${property._dbname_us} to required`, ignorable: true });
                     }
                     else if (!property.required && currentTable[property._dbname_us].required) {
                         changes.push({ message: `Change ${modelClass.table_name}.${column} to optional`, ignorable: true });

--- a/packages/cormo/lib/connection/index.js
+++ b/packages/cormo/lib/connection/index.js
@@ -137,7 +137,7 @@ class Connection extends events_1.EventEmitter {
                         const property = modelClass._schema[column];
                         if (!currentTable[property._dbname_us]) {
                             if (options.verbose) {
-                                console.log(`Adding column ${column} to ${modelClass.table_name}`);
+                                console.log(`Adding column ${property._dbname_us} to ${modelClass.table_name}`);
                             }
                             await this._adapter.addColumn(model, property);
                         }

--- a/packages/cormo/src/connection/index.ts
+++ b/packages/cormo/src/connection/index.ts
@@ -274,7 +274,7 @@ class Connection<AdapterType extends AdapterBase = AdapterBase> extends EventEmi
             const property = modelClass._schema[column];
             if (!currentTable[property._dbname_us]) {
               if (options.verbose) {
-                console.log(`Adding column ${column} to ${modelClass.table_name}`);
+                console.log(`Adding column ${property._dbname_us} to ${modelClass.table_name}`);
               }
               await this._adapter.addColumn(model, property);
             }

--- a/packages/cormo/src/connection/index.ts
+++ b/packages/cormo/src/connection/index.ts
@@ -367,10 +367,10 @@ class Connection<AdapterType extends AdapterBase = AdapterBase> extends EventEmi
       for (const column in modelClass._schema) {
         const property = modelClass._schema[column];
         if (!currentTable[property._dbname_us]) {
-          changes.push({ message: `Add column ${column} to ${modelClass.table_name}` });
+          changes.push({ message: `Add column ${property._dbname_us} to ${modelClass.table_name}` });
         } else if (column !== 'id') {
           if (property.required && !currentTable[property._dbname_us].required) {
-            changes.push({ message: `Change ${modelClass.table_name}.${column} to required`, ignorable: true });
+            changes.push({ message: `Change ${modelClass.table_name}.${property._dbname_us} to required`, ignorable: true });
           } else if (!property.required && currentTable[property._dbname_us].required) {
             changes.push({ message: `Change ${modelClass.table_name}.${column} to optional`, ignorable: true });
           }

--- a/packages/cormo/test/cases/schema.ts
+++ b/packages/cormo/test/cases/schema.ts
@@ -205,6 +205,21 @@ export default function(db: any, db_config: any) {
     expect(await connection.getSchemaChanges()).to.eql([]);
     expect(await connection.isApplyingSchemasNecessary()).to.eql(false); // no table to create
 
+    @cormo.Model({ name: 'users' })
+    @cormo.Index({ name: 1 })
+    class User3 extends cormo.BaseModel {
+      @cormo.Column({ type: String, name: 'n' })
+      public name!: string;
+
+      @cormo.Column({ type: Number, name: 'a2' })
+      public age!: number;
+    }
+    expect(await connection.getSchemaChanges()).to.eql([
+      { message: 'Add column a2 to users' },
+      { message: 'Remove column a from users', ignorable: true },
+    ]);
+    expect(await connection.isApplyingSchemasNecessary()).to.eql(true);
+
     await connection.applySchemas();
     expect(await connection.getSchemaChanges()).to.eql([]);
     expect(await connection.isApplyingSchemasNecessary()).to.eql(false);

--- a/packages/cormo/test/cases/schema.ts
+++ b/packages/cormo/test/cases/schema.ts
@@ -205,21 +205,6 @@ export default function(db: any, db_config: any) {
     expect(await connection.getSchemaChanges()).to.eql([]);
     expect(await connection.isApplyingSchemasNecessary()).to.eql(false); // no table to create
 
-    @cormo.Model({ name: 'users' })
-    @cormo.Index({ name: 1 })
-    class User3 extends cormo.BaseModel {
-      @cormo.Column({ type: String, name: 'n' })
-      public name!: string;
-
-      @cormo.Column({ type: Number, name: 'a2' })
-      public age!: number;
-    }
-    expect(await connection.getSchemaChanges()).to.eql([
-      { message: 'Add column a2 to users' },
-      { message: 'Remove column a from users', ignorable: true },
-    ]);
-    expect(await connection.isApplyingSchemasNecessary()).to.eql(true);
-
     await connection.applySchemas();
     expect(await connection.getSchemaChanges()).to.eql([]);
     expect(await connection.isApplyingSchemasNecessary()).to.eql(false);
@@ -417,6 +402,27 @@ export default function(db: any, db_config: any) {
         { message: 'Remove column address from users', ignorable: true },
       ]);
       expect(await connection.isApplyingSchemasNecessary()).to.eql(false);
+    } else {
+      expect(await connection.getSchemaChanges()).to.eql([]);
+      expect(await connection.isApplyingSchemasNecessary()).to.eql(false);
+    }
+  });
+
+  it('column is added', async () => {
+    class User extends cormo.BaseModel { }
+    User.column('name', String);
+
+    await connection.applySchemas();
+
+    User.column('address', String);
+    User.column('age', { type: String, name: 'a' });
+
+    if (db !== 'mongodb') {
+      expect(await connection.getSchemaChanges()).to.eql([
+        { message: 'Add column address to users' },
+        { message: 'Add column a to users' },
+      ]);
+      expect(await connection.isApplyingSchemasNecessary()).to.eql(true);
     } else {
       expect(await connection.getSchemaChanges()).to.eql([]);
       expect(await connection.isApplyingSchemasNecessary()).to.eql(false);


### PR DESCRIPTION
```typescript
@CGColumn({ type: cormo.types.Integer, name: 'before'  })
ts_field?: number;
```
```typescript
@CGColumn({ type: cormo.types.Integer, name: 'after'  })
ts_field?: number;
```
위에서 아래로 바꾸면 아래와 같은 결과가 나옵니다.
```
Add column ts_field to zigzag_notices
Remove column before from zigzag_notices (ignorable)
```
`ts_field`가 `after`로 나왔으면 좋겠습니다.