### PR TITLE
feat: mysql max lifetime 추가

### DIFF
--- a/packages/cormo/lib/adapters/mysql.d.ts
+++ b/packages/cormo/lib/adapters/mysql.d.ts
@@ -14,7 +14,7 @@ export interface AdapterSettingsMySQL {
     collation?: string;
     pool_size?: number;
     query_timeout?: number;
-    idle_timeout?: number;
+    max_lifetime?: number;
     replication?: {
         use_master_for_read?: boolean;
         read_replicas: Array<{

--- a/packages/cormo/lib/adapters/mysql.d.ts
+++ b/packages/cormo/lib/adapters/mysql.d.ts
@@ -14,6 +14,7 @@ export interface AdapterSettingsMySQL {
     collation?: string;
     pool_size?: number;
     query_timeout?: number;
+    idle_timeout?: number;
     replication?: {
         use_master_for_read?: boolean;
         read_replicas: Array<{

--- a/packages/cormo/lib/adapters/mysql.js
+++ b/packages/cormo/lib/adapters/mysql.js
@@ -795,7 +795,7 @@ class MySQLAdapter extends sql_base_1.SQLAdapterBase {
         this._client._node_id = 'MASTER';
         this._client.queryAsync = util_1.default.promisify(this._client.query);
         this._client.getConnectionAsync = util_1.default.promisify(this._client.getConnection);
-        this._setEvent(this._client, settings.idle_timeout);
+        this._setEvent(this._client, settings.max_lifetime);
         if (settings.replication) {
             this._read_clients = [];
             if (settings.replication.use_master_for_read) {
@@ -817,7 +817,7 @@ class MySQLAdapter extends sql_base_1.SQLAdapterBase {
                 read_client._node_id = `SLAVE${i + 1}`;
                 read_client.queryAsync = util_1.default.promisify(read_client.query);
                 read_client.getConnectionAsync = util_1.default.promisify(read_client.getConnection);
-                this._setEvent(read_client, settings.idle_timeout);
+                this._setEvent(read_client, settings.max_lifetime);
                 this._read_clients.push(read_client);
             }
         }
@@ -1281,15 +1281,15 @@ class MySQLAdapter extends sql_base_1.SQLAdapterBase {
         return MySQLAdapter.wrapError(msg, cause);
     }
     /** @internal */
-    _setEvent(client, idle_timeout) {
-        if (!idle_timeout || idle_timeout < 0) {
+    _setEvent(client, max_lifetime) {
+        if (!max_lifetime || max_lifetime < 0) {
             return;
         }
         client.on('connection', (connection) => {
             connection._connected_ts = Date.now();
         });
         client.on('release', (connection) => {
-            if (Date.now() - connection._connected_ts >= idle_timeout) {
+            if (Date.now() - connection._connected_ts >= max_lifetime) {
                 connection.destroy();
             }
         });

--- a/packages/cormo/src/adapters/mysql.ts
+++ b/packages/cormo/src/adapters/mysql.ts
@@ -1380,7 +1380,7 @@ export class MySQLAdapter extends SQLAdapterBase {
 
   /** @internal */
   private _setEvent(client: any, max_lifetime?: number) {
-    if (!max_lifetime || max_lifetime < 0) {
+    if (!max_lifetime || max_lifetime <= 0) {
       return;
     }
     client.on('connection', (connection: any) => {


### PR DESCRIPTION
배경
- replica 가 추가되면 무조건 배포를 해줘야만 새로운 노드로 접속이 됨
- replica 한쪽으로 과도하게 쏠리는 현상이 좀 나아지지 않을까하는 1%의 기대감

작업
- 커넥션을 맺을때의 timestamp 추가
- 커넥션이 풀에 반납될때 시각을 비교해 커넥션 종료처리

고민
- 머지된다면 버전업 & 배포는 어떻게 하나요?